### PR TITLE
Add worker CLI --version flag

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -19,11 +18,12 @@ import (
 func main() {
 	p := pflag.NewFlagSet(workercmd.Name, pflag.ExitOnError)
 	p.String("config", "", "Configuration file")
-	if err := p.Parse(os.Args[1:]); err == flag.ErrHelp {
-		os.Exit(1)
-	} else if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+	p.Bool("version", false, "Show version information")
+	_ = p.Parse(os.Args[1:])
+
+	if v, _ := p.GetBool("version"); v {
+		fmt.Println(version.Info(workercmd.Name))
+		os.Exit(0)
 	}
 
 	var cfg config.Configuration

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,18 @@
+package version_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/preprocessing-moma/internal/version"
+)
+
+func TestVersion(t *testing.T) {
+	// The results below lack vcs build info due to bug:
+	// https://github.com/golang/go/issues/33976, and the output should include
+	// the expected git data when the bug is fixed.
+	assert.Equal(t, version.Short, "0.0.0-dev")
+	assert.Equal(t, version.Long, "0.0.0-dev-t")
+	assert.Equal(t, version.Info("testapp"), "testapp version 0.0.0-dev-t")
+}


### PR DESCRIPTION
- Add a "--version" flag to the worker that outputs the binary version info then exits
- Add a unit test for the version package